### PR TITLE
Add Ubuntu and Debian debuginfod servers

### DIFF
--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -31,6 +31,8 @@ HASHES = {
     'md5': md5filehex,
 }
 DEBUGINFOD_SERVERS = [
+    'https://debuginfod.ubuntu.com/',
+    'https://debuginfod.debian.net/',
     'https://debuginfod.elfutils.org/',
 ]
 


### PR DESCRIPTION
Most CTF challenges are hosted on Ubuntu or Debian [citation needed], so check their debuginfod servers before trying the federating one as a fallback.

This is required since the elfutils.org server seems down for maintenance occasionally.

(the stable branch doesn't have the libcdb cache yet, so this fixes CI)